### PR TITLE
Fix duplicate YAML keys and "titletitle" key typo

### DIFF
--- a/pcap.yml
+++ b/pcap.yml
@@ -1,6 +1,5 @@
-titletitle: Petite Capitals
+title: Petite Capitals
 registered: Tiro Typeworks / Emigre
-registered: Adobe
 state: discretionary
 automatic: true
 description: >

--- a/rclt.yml
+++ b/rclt.yml
@@ -5,7 +5,6 @@ script:
     order: 2
   syrc:
     order: 2
-state: required
 title: Required Contextual Alternates
 registered: Microsoft
 description: |

--- a/rlig.yml
+++ b/rlig.yml
@@ -5,7 +5,6 @@ script:
     order: 1
   syrc:
     order: 1
-state: required
 title: Required Ligatures
 registered: Microsoft
 description: |


### PR DESCRIPTION
Some stricter YAML parsers don't like duplicate keys.